### PR TITLE
Update typing-extensions to support versions >=4.10,<5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { text = "MIT" }
 requires-python = ">=3.10"
 dependencies = [
     "adaptix==3.0.0b11",
-    "typing_extensions~=4.10.0",
+    "typing_extensions>=4.10.0,<5.0.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
Because: ![telegram-cloud-photo-size-2-5231478198020210321-y](https://github.com/user-attachments/assets/b4fa5754-823e-4848-bfc6-bacbb8582f19)
